### PR TITLE
Support environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,34 @@ _ buy:xrp 750.000 "" bimo2
 # 2 `deposit bimo2 balance.to` <- [address] = "bimo2"
 ```
 
+### Environment
+
+DNA supports environment variables by defining them in the `env` object. Variables can be referenced in any command by prefixing the key with `&`:
+
+```json
+{
+  "_version": 0,
+  "env": {
+    "AMEX_CARD": "amex_2"
+  },
+  "scripts": {
+    "use_amex": {
+      "info": "Set default payment method (American Express)",
+      "commands": [
+        "pay -s &AMEX_CARD",
+      ]
+    }
+  }
+}
+```
+
+Executing the `use_amex` workflow defined above will execute as follows:
+
+```zsh
+_ use_amex
+# 0 `pay -s amex_2`
+```
+
 ### Comments
 
 Comments can be printed during execution by prefixing a command with `#` (space required). This can be useful to print logs or skipped steps in a workflow.

--- a/_/dna.go
+++ b/_/dna.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// VERSION : DNA version
-	VERSION = "0.2.1"
+	VERSION = "0.3.0"
 
 	// FILENAME : DNA config filename
 	FILENAME = "dna.json"

--- a/_/dna.go
+++ b/_/dna.go
@@ -69,7 +69,7 @@ func main() {
 			return
 		}
 
-		cli.ExecSync(&argv, &script, path)
+		cli.ExecSync(&argv, &script, &config.Env, path)
 	}
 }
 

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -15,6 +15,7 @@ const (
 // DNAFile : user defined DNA config
 type DNAFile struct {
 	Version int                  `json:"_version"`
+	Env     map[string]string    `json:"env"`
 	Scripts map[string]DNAScript `json:"scripts"`
 }
 


### PR DESCRIPTION
Resolves #3 

- Define environment variables in the `env` object
- Inject `env` values by replacing `&VAR` with referenced values